### PR TITLE
Roll Back Proxy Deprecation

### DIFF
--- a/enhancements/proxy/global-cluster-egress-proxy.md
+++ b/enhancements/proxy/global-cluster-egress-proxy.md
@@ -13,7 +13,7 @@ approvers:
   - "@eparis"
   - "@knobunc"
 creation-date: 2019-10-04
-last-updated: 2019-11-24
+last-updated: 2019-12-17
 status: implemented
 see-also:
   - "https://github.com/openshift/enhancements/pull/22"

--- a/enhancements/proxy/global-cluster-egress-proxy.md
+++ b/enhancements/proxy/global-cluster-egress-proxy.md
@@ -150,7 +150,7 @@ configmap after confirming the validation endpoints can be accessed using the ne
 
 Additional behaviors:
 
-* configmaps labeled with `config.openshift.io/inject-proxy-cabundle: "true"` will have the current
+* configmaps labeled with `config.openshift.io/inject-trusted-cabundle: "true"` will have the current
   set of additional CAs injected into them by logic in the cluster network operator.
 * deployments with the `config.openshift.io/inject-proxy: <container-name>` will get the current proxy
   environment variables injected (HTTP_PROXY, HTTPS_PROXY, NO_PROXY) by the cluster version operator.

--- a/enhancements/security/x509-trust.md
+++ b/enhancements/security/x509-trust.md
@@ -94,7 +94,7 @@ For example, the registry operator uses [`trusted-ca`][registry-configmap-name] 
 Components that have distinct trust domains may define multiple ConfigMaps for each domain.
 For example, there may be one ConfigMap for proxy/egress TLS, and another ConfigMap for [S/MIME][smime] verification.
 To populate that trust bundle, the cluster administrator can set labels on the ConfigMap(s).
-For example, [the `config.openshift.io/inject-proxy-cabundle` label](../proxy/global-cluster-egress-proxy.md#implementation-detailsnotesconstraints-optional) asks for the current proxy trust bundle.
+For example, [the `config.openshift.io/inject-trusted-cabundle` label](../proxy/global-cluster-egress-proxy.md#implementation-detailsnotesconstraints-optional) asks for the current proxy trust bundle.
 
 The cluster-version operator (CVO) [merges ConfigMaps][cluster-version-operator-EnsureConfigMap] by [clobbering any manifest-defined data][cluster-version-operator-mergeMap], [labels, and annotations][cluster-version-operator-EnsureObjectMeta].
 Data keys, labels, and annotations not defined in the manifest are ignored.
@@ -139,7 +139,7 @@ FIXME
 The network operator supports copying trust bundles between ConfigMaps based on labels on the target ConfigMaps.
 
 * [The `config.openshift.io/inject-default-cabundle` label](../proxy/global-cluster-egress-proxy.md#implementation-detailsnotesconstraints-optional) asks for the current [cluster-scoped default trust bundle](#cluster-scoped-default-trust).
-* [The `config.openshift.io/inject-proxy-cabundle` label](../proxy/global-cluster-egress-proxy.md#implementation-detailsnotesconstraints-optional) asks for the current proxy trust bundle.
+* [The `config.openshift.io/inject-trusted-cabundle` label](../proxy/global-cluster-egress-proxy.md#implementation-detailsnotesconstraints-optional) asks for the current proxy trust bundle.
     The network operator will fall back to [the cluster-scoped default trust bundle](#cluster-scoped-default-trust) if no proxy-specific trust bundle has been configured.
 
 If multiple labels are set `true`, the network operator will provide the union of the requested trust bundles.
@@ -169,21 +169,6 @@ FIXME
 ### Graduation Criteria
 
 FIXME
-
-#### Removing a deprecated feature
-
-Currently cluster components set `config.openshift.io/inject-trusted-cabundle` to receive the _proxy_ bundle, not [the cluster-scoped default trust bundle](#cluster-scoped-default-trust).
-And currently nothing populates `default-ca-bundle` (the installer uses [`user-ca-bundle`][installer-configmap-name]).
-So a hard cut to the approach described in this enhancement would remove configured additional trust from proxy-consuming components.
-This enhancement deprecates the `config.openshift.io/inject-trusted-cabundle` label in favor of the [new labels](#implementation-detailsnotesconstraints).
-The expected migration path is:
-
-1. The network operator learns about the new labels.
-    `config.openshift.io/inject-trusted-cabundle` is treated as a synonym for `config.openshift.io/inject-proxy-cabundle`.
-2. Existing proxy consumers migrate to `config.openshift.io/inject-proxy-cabundle`.
-3. The network operator adds an alert on any ConfigMaps with the `config.openshift.io/inject-trusted-cabundle` label, to notify cluster administrators about the deprecation.
-    This doesn't have to be an alert, it could happen through [the insights operator][insights-operator] instead.
-4. After a suitable deprecation period, the `config.openshift.io/inject-trusted-cabundle` handling is removed from the network operator.
 
 ### Version Skew Strategy
 

--- a/enhancements/security/x509-trust.md
+++ b/enhancements/security/x509-trust.md
@@ -72,7 +72,7 @@ Outgoing TLS probably needs similar configuration, but that configuration is dec
 
 ### Cluster-scoped Default Trust
 
-There will be a ConfigMap (FIXME: or should this be a new CRD under openshift/api?) named `default-ca-bundle` in the `openshift-config` namespace.
+There will be a ConfigMap named `default-ca-bundle` in the `openshift-config` namespace.
 The ConfigMap will have the following keys:
 
 * `ca-bundle.crt`, containing a PEM-encoded X.509 certificate bundle.


### PR DESCRIPTION
Rather than deprecate proxy components, we will expect components that want the CAs from the additionalTrustBundle to create a cofigmap that asks for the default trust bundle. If that component also requests the proxy CAs, then when the network-operator unions the CAs together, we expect that union to check for, and eliminate any duplicates in its final result. 